### PR TITLE
Add redirect with guard to search-results with query, fix some warnings

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { PageNotFoundComponent } from './core/components/page-not-found/page-not-found.component';
 import { AuthGuard } from './core/guards/auth.guard';
+import { RedirectGuard } from './core/guards/redirect.guard';
 
 const routes: Routes = [
   {
@@ -16,12 +17,12 @@ const routes: Routes = [
   {
     path: 'booking',
     loadChildren: () => import('./booking/booking.module').then((m) => m.BookingModule),
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard, RedirectGuard],
   },
   {
     path: 'cart',
     loadChildren: () => import('./cart/cart.module').then((m) => m.CartModule),
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard, RedirectGuard],
   },
   {
     path: 'profile',

--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -18,8 +18,8 @@
             *ngIf="activeSearchStep"
             ngSrc="assets/icons/check_icon.svg"
             alt="current-step icon"
-            height="9"
-            width="10"
+            height="8"
+            width="11"
           />
         </div>
         <span>Flights</span>

--- a/src/app/core/guards/redirect.guard.ts
+++ b/src/app/core/guards/redirect.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { IQueryParams } from '../models/query-params.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RedirectGuard {
+  constructor(private router: Router) {}
+
+  canActivate: CanActivateFn = () => {
+    const queryParams: IQueryParams = JSON.parse(localStorage.getItem('query') || '0');
+    if (!this.router.navigated && queryParams) {
+      return this.router.createUrlTree(['search', 'results'], { queryParams });
+    } else if (!this.router.navigated && !queryParams) {
+      return this.router.createUrlTree(['search']);
+    }
+    return true;
+  };
+}

--- a/src/app/search/components/search-criteria-edit-block/search-criteria-edit-block.component.ts
+++ b/src/app/search/components/search-criteria-edit-block/search-criteria-edit-block.component.ts
@@ -191,6 +191,7 @@ export class SearchCriteriaEditBlockComponent implements OnInit {
       child: formVal.amountOfPass?.child || 0,
       infant: formVal.amountOfPass?.infant || 0,
     };
+    localStorage.setItem('query', JSON.stringify(query));
     if (this.typeOfFlight === 'round') {
       this.apiService.getAllTickets();
       this.store.dispatch(ApiTicketsType());

--- a/src/app/search/components/search-form/search-form.component.ts
+++ b/src/app/search/components/search-form/search-form.component.ts
@@ -170,6 +170,7 @@ export class SearchFormComponent implements OnInit {
       child: formVal.amountOfPass?.child || 0,
       infant: formVal.amountOfPass?.infant || 0,
     };
+    localStorage.setItem('query', JSON.stringify(query));
     this.router.navigate(['search', 'results'], {
       queryParams: { ...query },
     });

--- a/src/app/search/components/search-info-block/search-info-block.component.html
+++ b/src/app/search/components/search-info-block/search-info-block.component.html
@@ -7,7 +7,7 @@
         ngSrc="assets/icons/airPlainArrows.svg"
         alt="Arrows"
         width="24"
-        height="24"
+        height="16"
       />
       <span>{{ to }}</span>
     </div>


### PR DESCRIPTION
Реализовал автоматический редирект при перезагрузке:
1. В случае перехода и наличия query пути в локал сторедж, редирект на страницу с выдачей, 
2. В случае отсутствия на главную. Т.к. квери сетятся уже при первом сабмите search-form, ситуация где нет квери, может быть, если человек не разу не сабмитил эту форму, или очистил кэш.
Пофиксил несколько размеров картинок, на 1-2 пикселя вроде, что для того, что бы убрать варнинги.

P.S. Если вам понадобится тот же функционал редиректа в ваших компонентах, вам необходимо добавить canActivate: [RedirectGuard], в роутинг этого компонента.

#38 